### PR TITLE
Add headerbar to homepage

### DIFF
--- a/src/files/css/main.css
+++ b/src/files/css/main.css
@@ -142,7 +142,6 @@ header, section {
 .header-bar {
     background-color: rgba(22, 100, 151, .8);
     box-shadow: 0 3px 1px 0 rgba(0, 0, 0, .1);
-    margin-bottom: 40px;
     text-align: left;
 }
 

--- a/src/layouts/home.html.eco
+++ b/src/layouts/home.html.eco
@@ -1,5 +1,5 @@
 <%- @partial('header') %>
-
+<%- @partial('menu') %>
 <%- @content %>
 
 <%- @partial('footer') %>


### PR DESCRIPTION
Something that was bugging me a little is that the site has a top-level navigation bar for individual pages but this isn't shown on the homepage. This comes with the cost of:
- Needing to search through cards to dive into a section
- Not being able to get to items like the Sandbox which don't have a card
- Not being able to easily share the page or follow the project (something that can be done on all other pages).

This PR adds the existing header bar to the homepage. Feel free to close if you disagree, but I think it would be great to resolve some of these tiny issues :)

![preview](https://f.cloud.github.com/assets/110953/2271309/070cd666-9ef9-11e3-8b7e-63d8cea5d47f.png)
