### PR TITLE
Fix order of Articles and Presentations

### DIFF
--- a/docpad.js
+++ b/docpad.js
@@ -189,6 +189,26 @@ module.exports = {
             var i = content.search("<!-- Read more -->");
 
             return i >= 0;
+        },
+
+        fixOrder: function(documentsList){
+            var documentsEven = [],
+                documentsOdd = [],
+                i = 0;
+
+            if (!Array.isArray(documentsList)) {
+                return documentsList;
+            }
+
+            for (; i < documentsList.length; i++) {
+                if (i%2 === 0) {
+                    documentsEven.push(documentsList[i]);
+                } else {
+                    documentsOdd.push(documentsList[i]);
+                }
+            }
+
+            return documentsEven.concat(documentsOdd);
         }
     },
 

--- a/src/documents/articles/index.html.eco
+++ b/src/documents/articles/index.html.eco
@@ -7,7 +7,7 @@ pagedCollection: 'articles'
 pageSize: 6
 ---
 
-<% for item in @getPageCollection("articles").toJSON(): %>
+<% for item in @fixOrder(@getPageCollection("articles").toJSON()): %>
     <section class="card card-story card-articles">
         <% if item.image: %>
             <a <% if item.link: %>target="_blank"<% end %> class="story-image" href="<% if item.link: %><%= item.link %><% else: %><%= @site.url %><%= item.url %><% end %>">

--- a/src/documents/presentations/index.html.eco
+++ b/src/documents/presentations/index.html.eco
@@ -7,7 +7,7 @@ pagedCollection: 'presentations'
 pageSize: 6
 ---
 
-<% for item in @getPageCollection("presentations").toJSON(): %>
+<% for item in @fixOrder(@getPageCollection("presentations").toJSON()): %>
     <section class="card card-story card-presentations">
         <% if item.image: %>
             <a <% if item.link: %>target="_blank"<% end %> class="story-image" href="<% if item.link: %><%= item.link %><% else: %><%= @site.url %><%= item.url %><% end %>">


### PR DESCRIPTION
Create fixOrder function that reorder the array of documents of that
page and return the array in the proper order.

Change the index template of articles and presentations to call the
fixOrder function

Fix #48
