### PR TITLE
Use iframe for g+ button

### DIFF
--- a/src/partials/menu.html.eco
+++ b/src/partials/menu.html.eco
@@ -28,14 +28,7 @@
                 <iframe src="//www.facebook.com/plugins/like.php?href=<%= @site.url %>&amp;send=false&amp;layout=button_count&amp;width=90&amp;show_faces=false&amp;font&amp;colorscheme=light&amp;action=like&amp;height=21&amp;appId=176947299114210" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:90px; height:21px;" allowTransparency="true"></iframe>
             </li>
             <li class="gplus-btn">
-                <div class="g-plusone" data-size="medium"></div>
-                <script type="text/javascript">
-                    (function() {
-                        var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
-                        po.src = 'https://apis.google.com/js/plusone.js';
-                        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
-                    })();
-                </script>
+                <iframe height="21" width="110" src="https://plusone.google.com/_/+1/fastbutton?bsv&amp;size=medium&amp;hl=en-US&amp;url=http://webcomponents.github.io/&amp;parent=http://webcomponents.github.io/" allowtransparency="true" frameborder="0" scrolling="no" title="Google Plus"></iframe>
             </li>
         </ul>
     </div>


### PR DESCRIPTION
These are my arguments for approval of this PR:
- Consistency. Today all the share buttons in the header are iframes
- This increases the score of PageSpeed, mobile ​​to 75 and desktop to 88 (See [this](http://developers.google.com/speed/pagespeed/insights/?url=http%3A%2F%2Fluanmuniz.github.io%2Fwebcomponents.github.io%2F&tab=mobile) link)
- Now the build will not fail \o/
- Fix in part #74. Now the g+ button are always for the homepage, like the facebook button (In part because twitter are still pointing to the current page) and even if we want to always point to the current page, we can approve this PR and change both, this and the facebook button, in the next PR. The iframe isn't relevant to this issue.

What do you think?
