### PR TITLE
Add article on principles for creating general-purpose components

### DIFF
--- a/authors.js
+++ b/authors.js
@@ -63,6 +63,13 @@ module.exports = {
         gplus: "+EricBidelman",
         twitter: "ebidel"
     },
+    jan_miksovsky: {
+        name: "Jan Miksovsky",
+        bio: "Jan is a user experience designer/developer. He's the founder of Component Kitchen, a startup focusing on promoting web components.",
+        gravatar: "eab84bbf714f065bbfece0c58d9fc6c3",
+        gplus: "+JanMiksovsky",
+        twitter: "JanMiksovsky"
+    },
     mark_dalgleish: {
         name: "Mark Dalgleish",
         bio: "Mark is a senior UI developer at SEEK and the lead organiser of MelbJS. He’s obsessed with everything web and loves using JavaScript, CSS and HTML to create rich experiences that resonate with end users. In his spare time, he loves experimenting with the latest web technologies, sharing projects online and helping others learn progressive web development techniques.",

--- a/src/documents/articles/principles-for-general-purpose-components.md
+++ b/src/documents/articles/principles-for-general-purpose-components.md
@@ -1,0 +1,14 @@
+---
+title: Ten Principles for Great General-Purpose Web Components
+authors: [jan_miksovsky]
+date: 2014-06-13
+link: https://github.com/basic-web-components/components-dev/wiki/Ten-Principles-for-Great-General-Purpose-Web-Components
+category: articles
+layout: single
+---
+
+Creating really good general-purpose components entails more work than creating
+components for a single organization or product. To create components that
+measure up to the gold standard of the built-in HTML elements, your component
+will need to be useful right out of the box, work in a wide variety of
+circumstances, be composable into other components, and more.


### PR DESCRIPTION
I wrote these principles for the [Basic Web Components](https://github.com/basic-web-components/components-dev/wiki) project, but they're applicable to anyone creating general-purpose components for a broad audience. These principles are still evolving, but they've reached a point where I think they're worth sharing.

**Note**: When I build the site and check the formatting of the card on the Articles page, the line spacing looks different than for other articles. In the debugger, it appears that other article cards put the description in a paragraph tag inside a div, but in the card for the new article I'm submitting, the text is directly inside the div (no paragraph tag). It's the paragraph that sets the line-height, which is why the card looks off. However, I can't see any reason why the formatting on this article would be different than others — I started by copying the contents of one of the existing .md files. Please fix or let me know how to fix.
