### PR TITLE
Remove else in authors image

### DIFF
--- a/docpad.js
+++ b/docpad.js
@@ -31,9 +31,8 @@ module.exports = {
             if (this.authors[author].gravatar) {
                 return "https://2.gravatar.com/avatar/" + this.authors[author].gravatar;
             }
-            else {
-                return this.authors[author].image;
-            }
+            
+            return this.authors[author].image;
         },
 
         getAuthorGooglePlus: function(author) {


### PR DESCRIPTION
I think the most important of this function is return the image of the author. If it has an image of the gravatar, this function return the image of gravatar.

In this case, the `else` is not necessary. This is just one way to write a better code, more clean. 
