### PR TITLE
URL change for jsbin.com in template article

### DIFF
--- a/src/documents/articles/introduction-to-template-element.html.md
+++ b/src/documents/articles/introduction-to-template-element.html.md
@@ -101,7 +101,7 @@ In order to stamp out the template, you'll need to write a bit of JavaScript.
     </script>
     <div id="host"></div>
   
-[Here's a live example](http://jsbin.com/qaxiw/6/edit).  
+[Here's a live example](http://jsbin.com/qaxiw/7/edit).  
   
 The `template` node queried on first line will be cloned using
 `document.importNode()`. By assigning `true` to the 2nd argument, we are


### PR DESCRIPTION
There was a bug in jsbin sample. Fixed it and replaced the URL.
