### PR TITLE
Add presentations for talks given at Polytechnic event at Google Seattle, November 15, 2014

### DIFF
--- a/src/documents/presentations/components-101-intro-to-fundamental-changes-in-html.html.md
+++ b/src/documents/presentations/components-101-intro-to-fundamental-changes-in-html.html.md
@@ -1,0 +1,20 @@
+---
+title: Web Components 101: An Introduction to Fundamental Changes in HTML
+authors: [jan_miksovsky]
+event: Polytechnic Seattle
+date: 2014-11-15
+category: presentations
+layout: single
+---
+
+The set of specs that comprise web components — including Shadow DOM, custom elements, and HTML imports — represent more than just another framework for front-end user interface development. They are fundamental changes in the common language of the web itself, perhaps more important changes to the language than anything since the introduction of CSS. Web components will quickly become a standard part of every designer and developer’s world.
+
+<!-- Excerpt -->
+
+In this talk, Component Kitchen founder Jan Miksovsky introduces the basics of web components, showing how they can easily be created in Google’s Polymer framework. The [source code for all demos](https://github.com/JanMiksovsky/polytechnic-demos) in this talk are posted on GitHub.
+
+You can follow viewing of this talk with the companion talk, [Web Components 201: Designing Web Components for Reuse](//www.youtube.com/watch?v=dwxaG-eoxdU&t=5s).
+
+<div class="video-wrap">
+    <iframe src="//www.youtube.com/embed/hEzmy93zr0Y?start=540" itemprop="video"></iframe>
+</div>

--- a/src/documents/presentations/components-201-designing-components-for-reuse.html.md
+++ b/src/documents/presentations/components-201-designing-components-for-reuse.html.md
@@ -1,0 +1,22 @@
+---
+title: Web Components 201: Designing Web Components for Reuse
+authors: [jan_miksovsky]
+event: Polytechnic Seattle
+date: 2014-11-15
+category: presentations
+layout: single
+---
+
+Getting the most out of web components requires a change in mindset. Component Kitchen founder Jan Miksovsky presents a set of principles for creating components that can quickly be remixed and adapted in a variety of applications. This is a more advanced talk that assumes basic familiarity with web components and Google’s Polymer framework.
+
+<!-- Excerpt -->
+
+The [source code for all demos](https://github.com/JanMiksovsky/polytechnic-demos) in this talk are posted on GitHub. The talk
+references a set of [Ten Principles for Great General Purpose Web Components](https://github.com/basic-web-components/components-dev/wiki/Ten-Principles-for-Great-General-Purpose-Web-Components).
+
+This talk was the second in a series of two. The first, introductory talk is
+[Web Components 101: An Introduction to Fundamental Changes in HTML](//youtu.be/hEzmy93zr0Y?t=9m).
+
+<div class="video-wrap">
+    <iframe src="//www.youtube.com/embed/dwxaG-eoxdU?start=5" itemprop="video"></iframe>
+</div>


### PR DESCRIPTION
Here are two talks I gave at the Polytechnic event at Google's office in Seattle. These talks did _not_ use the stock slide decks provided for the event. Instead, both are live code demos written from scratch for the event.
1. The first talk is an intro to web components. It walks through the significance of the relevant specs through code examples. For this talk, it was fun to show _native_ components first in Chrome, then tackle webcomponents.js only later in the talk when discussing older browsers!
2. The second talk is a more advanced one covering some patterns for component reuse. This covers four examples in live code. The third example, a monthly calendar component, introduces a new, general pattern for highly reusable components.
