### PR TITLE
document-fragment -> shadow-root

### DIFF
--- a/src/documents/polyfills/shadow-dom.html.md
+++ b/src/documents/polyfills/shadow-dom.html.md
@@ -33,7 +33,7 @@ element as a normal subtree. They can access `.childNodes`, `.children`, `.inner
 `<my-custom-element>` may define shadow DOM by attaching a shadow root to
 itself.
 
-    #document-fragment
+    #shadow-root
       <!-- everything in here is my-custom-element's shadow DOM -->
       <span>People say: <content></content></span>
       <footer>sometimes</footer>


### PR DESCRIPTION
I'm assuming - but don't know for sure - that `#document-fragment` should now be `#shadow-root`. If the PR is accepted then I know that's correct. If not, then I've also got may answer :)

<img width="506" alt="screen shot 2015-07-28 at 12 15 39" src="https://cloud.githubusercontent.com/assets/328367/8941138/c4c72150-3522-11e5-9a41-18730fb5df42.png">