### PR TITLE
Update some dependencies, ensure docpad compatibility to node stable version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: node_js
 node_js:
+  - '4.1'
   - '0.12'
   - '0.10'

--- a/README.md
+++ b/README.md
@@ -59,12 +59,6 @@ To install it and all the other dependencies, run:
 $ npm install -g grunt-cli
 ```
 
-To install [Bower](http://bower.io/) dependencies, run:
-
-```sh
-$ grunt bower
-```
-
 To check performance regressions, run:
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -1,29 +1,29 @@
 {
   "private": true,
   "dependencies": {
-    "docpad": "^6.78.1",
-    "docpad-plugin-cleanurls": "^2.7.0",
-    "docpad-plugin-eco": "^2.1.0",
-    "docpad-plugin-ghpages": "^2.4.2",
-    "docpad-plugin-grunt": "^2.1.1",
-    "docpad-plugin-highlightjs": "^2.2.0",
-    "docpad-plugin-marked": "^2.2.0",
-    "docpad-plugin-moment": "^2.0.2",
-    "docpad-plugin-paged": "^2.2.4",
-    "docpad-plugin-partials": "^2.9.0",
-    "docpad-plugin-rss": "^2.1.4",
-    "docpad-plugin-tags": "^2.0.7"
+    "docpad": "~6.78.4",
+    "docpad-plugin-cleanurls": "~2.8.1",
+    "docpad-plugin-eco": "~2.1.0",
+    "docpad-plugin-ghpages": "~2.4.4",
+    "docpad-plugin-grunt": "~2.2.0",
+    "docpad-plugin-highlightjs": "~2.3.0",
+    "docpad-plugin-marked": "~2.3.0",
+    "docpad-plugin-moment": "~2.0.2",
+    "docpad-plugin-paged": "~2.4.0",
+    "docpad-plugin-partials": "~2.9.2",
+    "docpad-plugin-rss": "~2.2.0",
+    "docpad-plugin-tags": "~2.0.7"
   },
   "devDependencies": {
     "grunt": "~0.4.5",
     "grunt-cli": "~0.1.11",
     "grunt-contrib-clean": "~0.6.0",
-    "grunt-contrib-cssmin": "^0.12.2",
-    "grunt-contrib-htmlmin": "^0.4.0",
-    "grunt-imageoptim": "^1.4.1",
-    "grunt-lintspaces": "^0.7.0",
-    "grunt-pagespeed": "^1.0.0",
-    "load-grunt-tasks": "^3.1.0"
+    "grunt-contrib-cssmin": "~0.14.0",
+    "grunt-contrib-htmlmin": "~0.6.0",
+    "grunt-imageoptim": "~1.4.1",
+    "grunt-lintspaces": "~0.7.1",
+    "grunt-pagespeed": "~1.0.0",
+    "load-grunt-tasks": "~3.3.0"
   },
   "scripts": {
     "build": "docpad generate --env static",


### PR DESCRIPTION
Hello everyone.

Apparently I've been doing some cleaning work on DocPad-based repositories, hahaha. @zenorocha recommended me to take a look here.

I have updated docpad as well as its dependencies and added the stable version of Node as a compatible engine for Travis CI.

Also updated some other `grunt` dependencies and changed the `^` for `~` as it's less chance to break the building process if some dependency change the API considering they follow [semver](http://semver.org/).

**Off-topic:** I find it odd that bower is mentioned in the README file. There is no `grunt bower` task and no bower dependency so I removed the reference.

Please take a look at the PR and let me know if I need to change anything.

Thank you.