### PR TITLE
Webkit has support for shadow dom in nightly builds

### DIFF
--- a/src/documents/browser-support/safari.html
+++ b/src/documents/browser-support/safari.html
@@ -14,7 +14,7 @@ custom_elements: Not implemented yet
 custom_elements_status: red
 custom_elements_link:
 
-shadow_dom: Not implemented yet
-shadow_dom_status: red
-shadow_dom_link:
+shadow_dom: Nightly
+shadow_dom_status: yellow
+shadow_dom_link: https://www.webkit.org/blog/4096/introducing-shadow-dom-api/
 ---


### PR DESCRIPTION
Link to the WebKit blog post on shadowdom support in nightly builds.