### PR TITLE
Fix a typo

### DIFF
--- a/src/documents/polyfills/custom-elements.html.md
+++ b/src/documents/polyfills/custom-elements.html.md
@@ -118,7 +118,7 @@ The Custom Elements specification is still under discussion. The polyfill implem
 * `detachedCallback()` is called when a custom element is removed from a DOM subtree.
 * `attributeChangedCallback(attributeName)` is called when a custom element's attribute value has changed
 
-`createdCallback` is invoked _synchronously_ with element instantiation, the other callbacks are called _asyncronously_. The asynchronous callbacks generally use the MutationObserver timing model, which means they are called before layouts, paints, or other triggered events, so the developer need not worry about flashing content or other bad things happening before the callback has a chance to react to changes.
+`createdCallback` is invoked _synchronously_ with element instantiation, the other callbacks are called _asynchronously_. The asynchronous callbacks generally use the MutationObserver timing model, which means they are called before layouts, paints, or other triggered events, so the developer need not worry about flashing content or other bad things happening before the callback has a chance to react to changes.
 
 ## Tools & Testing
 


### PR DESCRIPTION
`asyncronously` → `asynchronously`