### PR TITLE
Update link to vulcanize doc

### DIFF
--- a/src/documents/articles/introduction-to-html-imports.html.md
+++ b/src/documents/articles/introduction-to-html-imports.html.md
@@ -162,7 +162,7 @@ $ vulcanize -o vulcanized.html index.html
 
 By executing this command, dependencies in `index.html` will be resolved and will generate an aggregated HTML file called `vulcanized.html`.
 
-Learn more about vulcanize [here](https://www.polymer-project.org/articles/concatenating-web-components.html).
+Learn more about vulcanize [here](https://www.polymer-project.org/1.0/docs/tools/optimize-for-production).
 
 Note: http2's server push abilities are considered to eliminate needs for concatenating and vulcanizing files in the future.
 


### PR DESCRIPTION
This was linking to the old 0.5 tutorial. I'll add a redirect on p-p.org site, but this should link to the newer doc.