### PR TITLE
Script path for the case of installation using npm

### DIFF
--- a/src/documents/polyfills/index.html.md
+++ b/src/documents/polyfills/index.html.md
@@ -41,6 +41,10 @@ Alternatively, you can install the Web Component polyfills using [npm](http://np
 
     npm install --save webcomponents.js
 
+Then, include `webcomponents.js` as you would any other script:
+
+    <script src="node_modules/webcomponents.js/webcomponents.js"></script>
+
 **Note**: Due to the nature of some of the polyfills, to maximize compatibility with other libraries, make sure that `webcomponents.js` is the first script tag in your document's `<head>`.
 
 Once included, you can use HTML Imports, Custom Elements, Shadow DOM, and other emerging standards within your app. For example, to use a webcomponents.js element, just import it using an HTML Import:


### PR DESCRIPTION
Makes it easier for beginners who use npm; They don't have to dig out the exact folder structure -> pretend them from becoming frustrated.