### PR TITLE
Update contribution instructions to correct NPM script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ If you are submitting a complete article for consideration, you don't need to in
 
 * Add your details (name, avatar, twitter handle etc) to `authors.js`. This will be used by our templates to show your name and links to your profiles.
 
-* Use `npm run-script watch` and `npm run-script generate` to preview the output of your article. Please double-check that all formatting is as expected.
+* Use `npm run-script watch` and `npm run-script build` to preview the output of your article. Please double-check that all formatting is as expected.
 
 * You can now follow the development steps below to submit a pull request for review :)
 
@@ -63,7 +63,7 @@ Please make sure to fill in the block with the `title`, `authors`, `date` and so
 
 * Add your details (name, avatar, twitter handle etc) to `authors.js`. This will be used by our templates to show your name and links to your profiles.
 
-* Use `npm run-script watch` and `npm run-script generate` to preview the output of your article. Please double-check that all formatting is as expected.
+* Use `npm run-script watch` and `npm run-script build` to preview the output of your article. Please double-check that all formatting is as expected.
 
 * You can now follow the development steps below to submit a pull request for review :)
 


### PR DESCRIPTION
In https://github.com/webcomponents/webcomponents.github.io/commit/e3887544b5750375b9e14d8ed936246bf25df2a7#diff-b9cfc7f2cdf78a7f4b91a753d10865a2 the NPM build script got changed from `generate` to `build` - the contribution docs need updating too.